### PR TITLE
KAN-51 - instant deps introduced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testing/tmp
 .idea
 unused/stand/*/bin/*
+/tmp/

--- a/common/data/pool/pool.go
+++ b/common/data/pool/pool.go
@@ -3,7 +3,7 @@ package pool
 import (
 	"context"
 	"fmt"
-	"kantoku/common/data/transaction"
+	"kantoku/common/data/transactional"
 )
 
 //type Reader[Item any] interface {
@@ -20,7 +20,7 @@ import (
 //}
 
 type Reader[Item any] interface {
-	Read(ctx context.Context) (<-chan transaction.Object[Item], error)
+	Read(ctx context.Context) (<-chan transactional.Object[Item], error)
 	//pool.Reader[Transaction[Item]]
 }
 
@@ -48,7 +48,7 @@ loop:
 		case <-ctx.Done():
 			break loop
 		case tx := <-ch:
-			err = func(tx transaction.Object[Item]) error {
+			err = func(tx transactional.Object[Item]) error {
 				item, err := tx.Get(ctx)
 				defer tx.Rollback(ctx)
 				if err != nil {

--- a/common/data/pool/pool.go
+++ b/common/data/pool/pool.go
@@ -1,16 +1,71 @@
 package pool
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"kantoku/common/data/transaction"
+)
+
+//type Reader[Item any] interface {
+//	Read(ctx context.Context) (<-chan Item, error)
+//}
+//
+//type Writer[Item any] interface {
+//	Write(ctx context.Context, item Item) error
+//}
+//
+//type Pool[Item any] interface {
+//	Reader[Item]
+//	Writer[Item]
+//}
 
 type Reader[Item any] interface {
-	Read(ctx context.Context) (<-chan Item, error)
+	Read(ctx context.Context) (<-chan transaction.Object[Item], error)
+	//pool.Reader[Transaction[Item]]
 }
 
+// Writer probably should have NewTransaction method
 type Writer[Item any] interface {
-	Write(ctx context.Context, item Item) error
+	// Write *must* write all items in a transaction!
+	Write(ctx context.Context, items ...Item) error
+	//pool.Writer[Item]
 }
 
 type Pool[Item any] interface {
 	Reader[Item]
 	Writer[Item]
+}
+
+func ReadAutoCommit[Item any](ctx context.Context, reader Reader[Item],
+	f func(ctx context.Context, item Item) error) error {
+	ch, err := reader.Read(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open read channel: %s", err)
+	}
+loop:
+	for {
+		select {
+		case <-ctx.Done():
+			break loop
+		case tx := <-ch:
+			err = func(tx transaction.Object[Item]) error {
+				item, err := tx.Get(ctx)
+				defer tx.Rollback(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to get item from transaction: %s", err)
+				}
+				if err := f(ctx, item); err != nil {
+					return err
+				}
+				if err := tx.Commit(ctx); err != nil {
+					return fmt.Errorf("failed to commit: %s", err)
+				}
+				return nil
+			}(tx)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }

--- a/common/data/transaction/object.go
+++ b/common/data/transaction/object.go
@@ -1,0 +1,9 @@
+package transaction
+
+import "context"
+
+type Object[Item any] interface {
+	Get(ctx context.Context) (Item, error)
+	Commit(ctx context.Context) error
+	Rollback(ctx context.Context) error
+}

--- a/common/data/transactional/object.go
+++ b/common/data/transactional/object.go
@@ -1,4 +1,4 @@
-package transaction
+package transactional
 
 import "context"
 

--- a/impl/common/data/pool/mem/transactional.go
+++ b/impl/common/data/pool/mem/transactional.go
@@ -1,0 +1,28 @@
+package mempool
+
+import (
+	"context"
+	"go/types"
+	"kantoku/common/data/transactional"
+)
+
+var _ transactional.Object[types.Object] = &Transaction[types.Object]{}
+
+type Transaction[T any] struct {
+	data    T
+	success chan bool
+}
+
+func (t *Transaction[T]) Get(ctx context.Context) (T, error) {
+	return t.data, nil
+}
+
+func (t *Transaction[T]) Commit(ctx context.Context) error {
+	t.success <- true
+	return nil
+}
+
+func (t *Transaction[T]) Rollback(ctx context.Context) error {
+	t.success <- false
+	return nil
+}

--- a/impl/deps/postgres/batched/batched.go
+++ b/impl/deps/postgres/batched/batched.go
@@ -6,7 +6,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"kantoku/common/data/pool"
-	"kantoku/common/data/transaction"
+	"kantoku/common/data/transactional"
 	"kantoku/impl/deps/postgres"
 	"kantoku/unused/backend/framework/depot/deps"
 	"log"
@@ -32,26 +32,26 @@ func New(client *pgxpool.Pool, queue pool.Pool[string]) *Deps {
 
 func (d *Deps) InitTables(ctx context.Context) error {
 	sql := `
-		CREATE TABLE Dependencies (
+		CREATE TABLE BatchedDependencies (
 			id varchar(255),
 			resolved bool,
 			PRIMARY KEY (id)
 		);
 		
-		CREATE TABLE Groups (
+		CREATE TABLE BatchedGroups (
 			id varchar(255),
 			pending int,
 			status varchar(16),
 			PRIMARY KEY (id)
 		);
 		
-		CREATE TABLE GroupDependencies (
+		CREATE TABLE BatchedGroupDependencies (
 			dependency_id varchar(255),
 			group_id varchar(255),
 			PRIMARY KEY (dependency_id, group_id),
 			CONSTRAINT fk_group
 			  FOREIGN KEY(group_id) 
-			  REFERENCES Groups(id)
+			  REFERENCES BatchedGroups(id)
 		      ON DELETE CASCADE
 		);
 	`
@@ -60,7 +60,7 @@ func (d *Deps) InitTables(ctx context.Context) error {
 }
 
 func (d *Deps) Dependency(ctx context.Context, id string) (deps.Dependency, error) {
-	sql := `SELECT id, resolved FROM Dependencies WHERE id = $1`
+	sql := `SELECT id, resolved FROM BatchedDependencies WHERE id = $1`
 	row := d.client.QueryRow(ctx, sql, id)
 
 	var model deps.Dependency
@@ -71,7 +71,7 @@ func (d *Deps) Dependency(ctx context.Context, id string) (deps.Dependency, erro
 }
 
 func (d *Deps) DropTables(ctx context.Context) error {
-	sql := `DROP TABLE Dependencies, Groups, GroupDependencies;`
+	sql := `DROP TABLE BatchedDependencies, BatchedGroups, BatchedGroupDependencies;`
 	_, err := d.client.Exec(ctx, sql)
 	return err
 }
@@ -80,8 +80,8 @@ func (d *Deps) Group(ctx context.Context, group string) (deps.Group, error) {
 	var result deps.Group
 	result.ID = group
 
-	sql := `SELECT dependency_id, COALESCE(resolved, false) FROM GroupDependencies gd 
-				LEFT JOIN Dependencies d ON d.id = gd.dependency_id
+	sql := `SELECT dependency_id, COALESCE(resolved, false) FROM BatchedGroupDependencies gd 
+				LEFT JOIN BatchedDependencies d ON d.id = gd.dependency_id
 				WHERE gd.group_id = $1`
 	records, err := d.client.Query(ctx, sql, group)
 	if err != nil {
@@ -125,14 +125,14 @@ func (d *Deps) MakeGroup(ctx context.Context, ids ...string) (string, error) {
 	}
 	defer tx.Rollback(ctx)
 
-	sql := `INSERT INTO Groups (id, pending, status) VALUES ($1, $2, $3)`
+	sql := `INSERT INTO BatchedGroups (id, pending, status) VALUES ($1, $2, $3)`
 	_, err = tx.Exec(ctx, sql, id, -1, status)
 	if err != nil {
 		return "", err
 	}
 
 	for _, dep := range ids {
-		sql := `INSERT INTO GroupDependencies (dependency_id, group_id) VALUES ($1, $2)`
+		sql := `INSERT INTO BatchedGroupDependencies (dependency_id, group_id) VALUES ($1, $2)`
 		_, err := tx.Exec(ctx, sql, dep, id)
 		if err != nil {
 			return "", err
@@ -156,11 +156,11 @@ func (d *Deps) Resolve(ctx context.Context, dep string) error {
 	sql := `
 		WITH previous AS (
 			SELECT resolved
-			FROM Dependencies
+			FROM BatchedDependencies
 			WHERE id = $1
 			LIMIT 1
 		)
-		INSERT INTO Dependencies (id, resolved) 
+		INSERT INTO BatchedDependencies (id, resolved) 
 		VALUES ($1, $2)
 		ON CONFLICT (id) DO UPDATE 
 		SET resolved = $2
@@ -175,9 +175,9 @@ func (d *Deps) Resolve(ctx context.Context, dep string) error {
 	}
 
 	sql = `
-			UPDATE Groups g
+			UPDATE BatchedGroups g
 			SET pending = pending - 1
-			FROM GroupDependencies gd
+			FROM BatchedGroupDependencies gd
 			WHERE gd.dependency_id = $1 AND gd.group_id = g.id`
 	if _, err := tx.Exec(ctx, sql, dep); err != nil {
 		return err
@@ -189,7 +189,7 @@ func (d *Deps) Resolve(ctx context.Context, dep string) error {
 	return nil
 }
 
-func (d *Deps) Ready(ctx context.Context) (<-chan transaction.Object[string], error) {
+func (d *Deps) Ready(ctx context.Context) (<-chan transactional.Object[string], error) {
 	return d.q.Read(ctx)
 }
 
@@ -236,14 +236,14 @@ func (d *Deps) initializeGroups(ctx context.Context) error {
 	sql := `
 		WITH uninitialized_groups AS (
 		   SELECT id
-		   FROM   Groups
+		   FROM   BatchedGroups
 		   WHERE  status = $1
 		   ) 
-		UPDATE Groups g
+		UPDATE BatchedGroups g
 		SET status = $2, pending = (
 			SELECT COUNT(*)
-				FROM GroupDependencies gd
-				LEFT OUTER JOIN Dependencies d ON d.id = gd.dependency_id
+				FROM BatchedGroupDependencies gd
+				LEFT OUTER JOIN BatchedDependencies d ON d.id = gd.dependency_id
 				WHERE gd.group_id = g.id
 					AND CASE WHEN d.resolved is NULL THEN true ELSE NOT d.resolved END
 		)
@@ -260,11 +260,11 @@ func (d *Deps) scheduleGroups(ctx context.Context, batchSize int) error {
 	sql := `
 		WITH groups_subset AS (
 		   SELECT id
-		   FROM   Groups
+		   FROM   BatchedGroups
 		   WHERE  status = $1 AND pending = 0
 		   LIMIT  $2
 		   )
-		UPDATE Groups g
+		UPDATE BatchedGroups g
 		SET    status = $3 
 		FROM   groups_subset
 		WHERE  g.id = groups_subset.id
@@ -298,7 +298,7 @@ func (d *Deps) scheduleGroups(ctx context.Context, batchSize int) error {
 	}
 
 	sql = `
-		UPDATE Groups g
+		UPDATE BatchedGroups g
 		SET    status = $1
 		FROM   (values ($2)) as s(id)
 		WHERE  g.id = s.id

--- a/impl/deps/postgres/batched/models.go
+++ b/impl/deps/postgres/batched/models.go
@@ -1,4 +1,4 @@
-package postgredeps
+package batched
 
 import (
 	"kantoku/unused/backend/framework/depot/deps"
@@ -26,5 +26,5 @@ const (
 type GroupModel struct {
 	ID      string `bson:"id"`
 	Pending int    `bson:"dependencies"`
-	Status  string
+	Status  string `bson:"status"`
 }

--- a/impl/deps/postgres/common.go
+++ b/impl/deps/postgres/common.go
@@ -1,0 +1,26 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"github.com/samber/lo"
+	"kantoku/unused/backend/framework/depot/deps"
+	"strings"
+)
+
+type Deps interface {
+	deps.Deps
+	Run(ctx context.Context)
+	InitTables(ctx context.Context) error
+	DropTables(ctx context.Context) error
+}
+
+func FormatValues(ids ...string) string {
+	values := strings.Join(
+		lo.Map(ids, func(item string, _ int) string {
+			return fmt.Sprintf("'%s'", item)
+		}),
+		", ")
+	values = fmt.Sprintf("(%s)", values)
+	return values
+}

--- a/impl/deps/postgres/common.go
+++ b/impl/deps/postgres/common.go
@@ -21,6 +21,6 @@ func FormatValues(ids ...string) string {
 			return fmt.Sprintf("'%s'", item)
 		}),
 		", ")
-	values = fmt.Sprintf("(%s)", values)
+	values = fmt.Sprintf("%s", values)
 	return values
 }

--- a/impl/deps/postgres/group.go
+++ b/impl/deps/postgres/group.go
@@ -1,4 +1,4 @@
-package postgredeps
+package postgres
 
 import (
 	"kantoku/unused/backend/framework/depot/deps"

--- a/impl/deps/postgres/instant/instant.go
+++ b/impl/deps/postgres/instant/instant.go
@@ -1,0 +1,237 @@
+package instant
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"kantoku/common/data/pool"
+	"kantoku/common/data/transaction"
+	"kantoku/impl/deps/postgres"
+	"kantoku/unused/backend/framework/depot/deps"
+	"log"
+)
+
+var _ postgres.Deps = &Deps{}
+
+type Deps struct {
+	resolvedGroups pool.Pool[string]
+	resolvedDeps   pool.Pool[string]
+	client         *pgxpool.Pool
+}
+
+// New creates an instance of the dependency manager with *instant* resolving.
+// client is a connection to a postgres database (all dependencies and groups are stored there)
+// queues are for storing resolved groups and deps, waiting to be processed
+func New(client *pgxpool.Pool, groupsQueue, depsQueue pool.Pool[string]) *Deps {
+	return &Deps{
+		resolvedGroups: groupsQueue,
+		resolvedDeps:   depsQueue,
+		client:         client,
+	}
+}
+
+func (d *Deps) InitTables(ctx context.Context) error {
+	sql := `
+		CREATE TABLE Dependencies (
+			id varchar(255),
+			resolved bool,
+			PRIMARY KEY (id)
+		);
+		
+		CREATE TABLE Groups (
+			id varchar(255),
+			pending int,
+			PRIMARY KEY (id)
+		);
+		
+		CREATE TABLE GroupDependencies (
+			dependency_id varchar(255),
+			group_id varchar(255),
+			PRIMARY KEY (dependency_id, group_id),
+			CONSTRAINT fk_group
+			  FOREIGN KEY(group_id) 
+			  REFERENCES Groups(id)
+		      ON DELETE CASCADE
+		);
+	`
+	_, err := d.client.Exec(ctx, sql)
+	return err
+}
+
+func (d *Deps) Dependency(ctx context.Context, id string) (deps.Dependency, error) {
+	sql := `SELECT id, resolved FROM Dependencies WHERE id = $1`
+	row := d.client.QueryRow(ctx, sql, id)
+
+	var model deps.Dependency
+	if err := row.Scan(&model.ID, &model.Resolved); err != nil {
+		return deps.Dependency{}, err
+	}
+	return model, nil
+}
+
+func (d *Deps) DropTables(ctx context.Context) error {
+	sql := `DROP TABLE Dependencies, Groups, GroupDependencies;`
+	_, err := d.client.Exec(ctx, sql)
+	return err
+}
+
+func (d *Deps) Group(ctx context.Context, group string) (deps.Group, error) {
+	var result deps.Group
+	result.ID = group
+
+	sql := `SELECT dependency_id, COALESCE(resolved, false) FROM GroupDependencies gd 
+				LEFT JOIN Dependencies d ON d.id = gd.dependency_id
+				WHERE gd.group_id = $1`
+	records, err := d.client.Query(ctx, sql, group)
+	if err != nil {
+		return result, err
+	}
+	defer records.Close()
+
+	for records.Next() {
+		var dep deps.Dependency
+		if err := records.Scan(&dep.ID, &dep.Resolved); err != nil {
+			return result, err
+		}
+		result.Dependencies = append(result.Dependencies, dep)
+	}
+
+	return result, nil
+}
+
+// Make generates a new dependency (but it does not store the information about it in the database
+//
+// Generation algorithm: UUID
+func (d *Deps) Make(ctx context.Context) (deps.Dependency, error) {
+	id := uuid.New().String()
+
+	return deps.Dependency{
+		ID:       id,
+		Resolved: false,
+	}, nil
+}
+
+// MakeGroup creates a new dependency group
+//
+// NOTE: the new group's id is generated via a UUID algorithm
+func (d *Deps) MakeGroup(ctx context.Context, ids ...string) (string, error) {
+	id := uuid.New().String()
+
+	tx, err := d.client.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to begin a postgres transaction: %s", tx)
+	}
+	defer tx.Rollback(ctx)
+
+	sql := `INSERT INTO Groups (id, pending)
+			VALUES ($1,
+			        $2 - (SELECT COUNT(*) FROM dependencies d WHERE d.resolved)
+			)`
+	_, err = tx.Exec(ctx, sql, id, len(ids))
+	if err != nil {
+		return "", err
+	}
+
+	for _, dep := range ids {
+		sql := `INSERT INTO GroupDependencies (dependency_id, group_id) VALUES ($1, $2)`
+		_, err := tx.Exec(ctx, sql, dep, id)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("failed to commit the transaction: %s", err)
+	}
+
+	return id, nil
+}
+
+func (d *Deps) Resolve(ctx context.Context, dep string) error {
+	if err := d.resolvedDeps.Write(ctx, dep); err != nil {
+		return fmt.Errorf("failed to write dep to queue: %s", err)
+	}
+	return nil
+}
+
+func (d *Deps) Ready(ctx context.Context) (<-chan transaction.Object[string], error) {
+	return d.resolvedGroups.Read(ctx)
+}
+
+func (d *Deps) Run(ctx context.Context) {
+	go d.runDepsProcessing(ctx)
+}
+
+func (d *Deps) runDepsProcessing(ctx context.Context) {
+	err := pool.ReadAutoCommit[string](ctx, d.resolvedDeps, d.processDep)
+	if err != nil {
+		log.Println("failed to open a resolved deps channel:", err)
+	}
+}
+
+func (d *Deps) processDep(ctx context.Context, dep string) error {
+	sql := `
+		INSERT INTO ProcessingDependencies (id)
+		VALUES ($1)`
+
+	if _, err := d.client.Exec(ctx, sql, dep); err != nil {
+		return fmt.Errorf("failed to register dep processing: %s", err)
+	}
+
+	tx, err := d.client.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to begin a postgres transaction: %s", tx)
+	}
+	defer tx.Rollback(ctx)
+	// let's goooooo
+	// 1) update dep and check if it has been resolved
+	sql = `
+		WITH previous AS (
+			SELECT resolved
+			FROM Dependencies
+			WHERE id = $1
+			LIMIT 1
+		)
+		INSERT INTO Dependencies (id, resolved) 
+		VALUES ($1, $2)
+		ON CONFLICT (id) DO UPDATE 
+		SET resolved = $2
+		RETURNING COALESCE((SELECT resolved FROM previous), false) AS previous_resolved;`
+	before := tx.QueryRow(ctx, sql, dep, true)
+	var alreadyResolved bool
+	if err := before.Scan(&alreadyResolved); err != nil {
+		return err
+	}
+	if alreadyResolved {
+		// if it resolved we are done
+		return nil
+	}
+
+	// dep hasn't been resolved, so we need to update groups
+	// we also return groups which have no unresolved deps
+	sql = `
+			UPDATE Groups g
+			SET pending = pending - 1
+			FROM GroupDependencies gd
+			WHERE gd.dependency_id = $1 AND gd.group_id = g.id
+			RETURNING (SELECT g.id WHERE g.pending = 0)` // returns new value
+	resolved, err := tx.Query(ctx, sql, dep)
+	var groups []string
+	for resolved.Next() {
+		var id string
+		if err := resolved.Scan(&id); err != nil {
+			return fmt.Errorf("failed to scan the id of a group (please report if it ever happens): %s", err)
+		}
+		groups = append(groups, id)
+	}
+	// now we just add groups to their queue
+	if err := d.resolvedGroups.Write(ctx, groups...); err != nil {
+		return fmt.Errorf("failed to add groups to queue")
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("failed to commit the transaction: %s", err)
+	}
+	return nil
+}

--- a/impl/deps/postgres/instant/instant.go
+++ b/impl/deps/postgres/instant/instant.go
@@ -6,10 +6,9 @@ import (
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"kantoku/common/data/pool"
-	"kantoku/common/data/transaction"
+	"kantoku/common/data/transactional"
 	"kantoku/impl/deps/postgres"
 	"kantoku/unused/backend/framework/depot/deps"
-	"log"
 )
 
 var _ postgres.Deps = &Deps{}
@@ -33,25 +32,25 @@ func New(client *pgxpool.Pool, groupsQueue, depsQueue pool.Pool[string]) *Deps {
 
 func (d *Deps) InitTables(ctx context.Context) error {
 	sql := `
-		CREATE TABLE Dependencies (
+		CREATE TABLE InstantDependencies (
 			id varchar(255),
 			resolved bool,
 			PRIMARY KEY (id)
 		);
 		
-		CREATE TABLE Groups (
+		CREATE TABLE InstantGroups (
 			id varchar(255),
 			pending int,
 			PRIMARY KEY (id)
 		);
 		
-		CREATE TABLE GroupDependencies (
+		CREATE TABLE InstantGroupDependencies (
 			dependency_id varchar(255),
 			group_id varchar(255),
 			PRIMARY KEY (dependency_id, group_id),
 			CONSTRAINT fk_group
 			  FOREIGN KEY(group_id) 
-			  REFERENCES Groups(id)
+			  REFERENCES InstantGroups(id)
 		      ON DELETE CASCADE
 		);
 	`
@@ -60,7 +59,7 @@ func (d *Deps) InitTables(ctx context.Context) error {
 }
 
 func (d *Deps) Dependency(ctx context.Context, id string) (deps.Dependency, error) {
-	sql := `SELECT id, resolved FROM Dependencies WHERE id = $1`
+	sql := `SELECT id, resolved FROM InstantDependencies WHERE id = $1`
 	row := d.client.QueryRow(ctx, sql, id)
 
 	var model deps.Dependency
@@ -71,7 +70,7 @@ func (d *Deps) Dependency(ctx context.Context, id string) (deps.Dependency, erro
 }
 
 func (d *Deps) DropTables(ctx context.Context) error {
-	sql := `DROP TABLE Dependencies, Groups, GroupDependencies;`
+	sql := `DROP TABLE InstantDependencies, InstantGroups, InstantGroupDependencies;`
 	_, err := d.client.Exec(ctx, sql)
 	return err
 }
@@ -80,8 +79,8 @@ func (d *Deps) Group(ctx context.Context, group string) (deps.Group, error) {
 	var result deps.Group
 	result.ID = group
 
-	sql := `SELECT dependency_id, COALESCE(resolved, false) FROM GroupDependencies gd 
-				LEFT JOIN Dependencies d ON d.id = gd.dependency_id
+	sql := `SELECT dependency_id, COALESCE(resolved, false) FROM InstantGroupDependencies gd 
+				LEFT JOIN InstantDependencies d ON d.id = gd.dependency_id
 				WHERE gd.group_id = $1`
 	records, err := d.client.Query(ctx, sql, group)
 	if err != nil {
@@ -124,9 +123,9 @@ func (d *Deps) MakeGroup(ctx context.Context, ids ...string) (string, error) {
 	}
 	defer tx.Rollback(ctx)
 
-	sql := `INSERT INTO Groups (id, pending)
+	sql := `INSERT INTO InstantGroups (id, pending)
 			VALUES ($1,
-			        $2 - (SELECT COUNT(*) FROM dependencies d WHERE d.resolved)
+			        $2 - (SELECT COUNT(*) FROM InstantDependencies d WHERE d.resolved)
 			)`
 	_, err = tx.Exec(ctx, sql, id, len(ids))
 	if err != nil {
@@ -134,7 +133,7 @@ func (d *Deps) MakeGroup(ctx context.Context, ids ...string) (string, error) {
 	}
 
 	for _, dep := range ids {
-		sql := `INSERT INTO GroupDependencies (dependency_id, group_id) VALUES ($1, $2)`
+		sql := `INSERT INTO InstantGroupDependencies (dependency_id, group_id) VALUES ($1, $2)`
 		_, err := tx.Exec(ctx, sql, dep, id)
 		if err != nil {
 			return "", err
@@ -149,35 +148,10 @@ func (d *Deps) MakeGroup(ctx context.Context, ids ...string) (string, error) {
 }
 
 func (d *Deps) Resolve(ctx context.Context, dep string) error {
-	if err := d.resolvedDeps.Write(ctx, dep); err != nil {
-		return fmt.Errorf("failed to write dep to queue: %s", err)
-	}
-	return nil
-}
-
-func (d *Deps) Ready(ctx context.Context) (<-chan transaction.Object[string], error) {
-	return d.resolvedGroups.Read(ctx)
-}
-
-func (d *Deps) Run(ctx context.Context) {
-	go d.runDepsProcessing(ctx)
-}
-
-func (d *Deps) runDepsProcessing(ctx context.Context) {
-	err := pool.ReadAutoCommit[string](ctx, d.resolvedDeps, d.processDep)
-	if err != nil {
-		log.Println("failed to open a resolved deps channel:", err)
-	}
-}
-
-func (d *Deps) processDep(ctx context.Context, dep string) error {
-	sql := `
-		INSERT INTO ProcessingDependencies (id)
-		VALUES ($1)`
-
-	if _, err := d.client.Exec(ctx, sql, dep); err != nil {
-		return fmt.Errorf("failed to register dep processing: %s", err)
-	}
+	//if err := d.resolvedDeps.Write(ctx, dep); err != nil {
+	//	return fmt.Errorf("failed to write dep to queue: %s", err)
+	//}
+	//return nil
 
 	tx, err := d.client.Begin(ctx)
 	if err != nil {
@@ -186,14 +160,14 @@ func (d *Deps) processDep(ctx context.Context, dep string) error {
 	defer tx.Rollback(ctx)
 	// let's goooooo
 	// 1) update dep and check if it has been resolved
-	sql = `
+	sql := `
 		WITH previous AS (
 			SELECT resolved
-			FROM Dependencies
+			FROM InstantDependencies
 			WHERE id = $1
 			LIMIT 1
 		)
-		INSERT INTO Dependencies (id, resolved) 
+		INSERT INTO InstantDependencies (id, resolved) 
 		VALUES ($1, $2)
 		ON CONFLICT (id) DO UPDATE 
 		SET resolved = $2
@@ -211,9 +185,9 @@ func (d *Deps) processDep(ctx context.Context, dep string) error {
 	// dep hasn't been resolved, so we need to update groups
 	// we also return groups which have no unresolved deps
 	sql = `
-			UPDATE Groups g
+			UPDATE InstantGroups g
 			SET pending = pending - 1
-			FROM GroupDependencies gd
+			FROM InstantGroupDependencies gd
 			WHERE gd.dependency_id = $1 AND gd.group_id = g.id
 			RETURNING (SELECT g.id WHERE g.pending = 0)` // returns new value
 	resolved, err := tx.Query(ctx, sql, dep)
@@ -235,3 +209,76 @@ func (d *Deps) processDep(ctx context.Context, dep string) error {
 	}
 	return nil
 }
+
+func (d *Deps) Ready(ctx context.Context) (<-chan transactional.Object[string], error) {
+	return d.resolvedGroups.Read(ctx)
+}
+
+func (d *Deps) Run(ctx context.Context) {
+	//go d.runDepsProcessing(ctx)
+}
+
+//func (d *Deps) runDepsProcessing(ctx context.Context) {
+//	err := pool.ReadAutoCommit[string](ctx, d.resolvedDeps, d.processDep)
+//	if err != nil {
+//		log.Println("failed to open a resolved deps channel:", err)
+//	}
+//}
+
+//func (d *Deps) processDep(ctx context.Context, dep string) error {
+//	tx, err := d.client.Begin(ctx)
+//	if err != nil {
+//		return fmt.Errorf("failed to begin a postgres transaction: %s", tx)
+//	}
+//	defer tx.Rollback(ctx)
+//	// let's goooooo
+//	// 1) update dep and check if it has been resolved
+//	sql := `
+//		WITH previous AS (
+//			SELECT resolved
+//			FROM InstantDependencies
+//			WHERE id = $1
+//			LIMIT 1
+//		)
+//		INSERT INTO InstantDependencies (id, resolved)
+//		VALUES ($1, $2)
+//		ON CONFLICT (id) DO UPDATE
+//		SET resolved = $2
+//		RETURNING COALESCE((SELECT resolved FROM previous), false) AS previous_resolved;`
+//	before := tx.QueryRow(ctx, sql, dep, true)
+//	var alreadyResolved bool
+//	if err := before.Scan(&alreadyResolved); err != nil {
+//		return err
+//	}
+//	if alreadyResolved {
+//		// if it resolved we are done
+//		return nil
+//	}
+//
+//	// dep hasn't been resolved, so we need to update groups
+//	// we also return groups which have no unresolved deps
+//	sql = `
+//			UPDATE InstantGroups g
+//			SET pending = pending - 1
+//			FROM InstantGroupDependencies gd
+//			WHERE gd.dependency_id = $1 AND gd.group_id = g.id
+//			RETURNING (SELECT g.id WHERE g.pending = 0)` // returns new value
+//	resolved, err := tx.Query(ctx, sql, dep)
+//	var groups []string
+//	for resolved.Next() {
+//		var id string
+//		if err := resolved.Scan(&id); err != nil {
+//			return fmt.Errorf("failed to scan the id of a group (please report if it ever happens): %s", err)
+//		}
+//		groups = append(groups, id)
+//	}
+//	// now we just add groups to their queue
+//	if err := d.resolvedGroups.Write(ctx, groups...); err != nil {
+//		return fmt.Errorf("failed to add groups to queue")
+//	}
+//
+//	if err := tx.Commit(ctx); err != nil {
+//		return fmt.Errorf("failed to commit the transaction: %s", err)
+//	}
+//	return nil
+//}

--- a/testing/common/data/pool/pool_test.go
+++ b/testing/common/data/pool/pool_test.go
@@ -124,7 +124,7 @@ func TestPool(t *testing.T) {
 
 			ctx := context.Background()
 
-			for i := 1; i <= 10; i++ {
+			for i := 0; i <= 10; i++ {
 				// Generate a random number
 				generated := uuid.New().String()
 

--- a/testing/unused/backend/depot/deps/deps_test.go
+++ b/testing/unused/backend/depot/deps/deps_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	mempool "kantoku/impl/common/data/pool/mem"
-	"kantoku/impl/deps/postgredeps"
+	"kantoku/impl/deps/postgres/batched"
 	"kantoku/unused/backend/framework/depot/deps"
 	"testing"
 	"time"
 )
 
-func newPostgresDeps(ctx context.Context) *postgredeps.Deps {
+func newPostgresDeps(ctx context.Context) *batched.Deps {
 	client, err := pgxpool.New(ctx, "postgres://postgres:51413@localhost:5432/")
 
 	if err != nil {
@@ -23,7 +23,7 @@ func newPostgresDeps(ctx context.Context) *postgredeps.Deps {
 		panic("failed to make ping postgres: " + err.Error())
 	}
 
-	app := postgredeps.New(client, mempool.New[string]())
+	app := batched.New(client, mempool.New[string]())
 	err = app.DropTables(ctx)
 	if err != nil {
 		panic("failed to init postgres tables: " + err.Error())

--- a/testing/unused/backend/depot/deps/deps_test.go
+++ b/testing/unused/backend/depot/deps/deps_test.go
@@ -49,7 +49,7 @@ func newInstantDeps(ctx context.Context) deps.Deps {
 		panic("failed to make ping postgres: " + err.Error())
 	}
 
-	app := instant.New(client, mempool.New[string](mempool.DefaultConfig), mempool.New[string](mempool.DefaultConfig))
+	app := instant.New(client, mempool.New[string](mempool.DefaultConfig))
 	err = app.DropTables(ctx)
 	if err != nil {
 		panic("failed to init postgres tables: " + err.Error())

--- a/unused/backend/framework/depot/deps/deps.go
+++ b/unused/backend/framework/depot/deps/deps.go
@@ -2,7 +2,7 @@ package deps
 
 import (
 	"context"
-	"kantoku/common/data/transaction"
+	"kantoku/common/data/transactional"
 )
 
 type Deps interface {
@@ -11,5 +11,5 @@ type Deps interface {
 	Group(ctx context.Context, id string) (Group, error)
 	Make(ctx context.Context) (Dependency, error)                 // creates a single dependency
 	MakeGroup(ctx context.Context, ids ...string) (string, error) // creates a group from a set of dependencies
-	Ready(ctx context.Context) (<-chan transaction.Object[string], error)
+	Ready(ctx context.Context) (<-chan transactional.Object[string], error)
 }

--- a/unused/backend/framework/depot/deps/deps.go
+++ b/unused/backend/framework/depot/deps/deps.go
@@ -1,6 +1,9 @@
 package deps
 
-import "context"
+import (
+	"context"
+	"kantoku/common/data/transaction"
+)
 
 type Deps interface {
 	Dependency(ctx context.Context, id string) (Dependency, error)
@@ -8,5 +11,5 @@ type Deps interface {
 	Group(ctx context.Context, id string) (Group, error)
 	Make(ctx context.Context) (Dependency, error)                 // creates a single dependency
 	MakeGroup(ctx context.Context, ids ...string) (string, error) // creates a group from a set of dependencies
-	Ready(ctx context.Context) (<-chan string, error)
+	Ready(ctx context.Context) (<-chan transaction.Object[string], error)
 }

--- a/unused/backend/stand/common/platform.go
+++ b/unused/backend/stand/common/platform.go
@@ -10,7 +10,7 @@ import (
 	rebimap "kantoku/impl/common/data/bimap/redis"
 	redikv "kantoku/impl/common/data/kv/redis"
 	redipool "kantoku/impl/common/data/pool/redis"
-	"kantoku/impl/deps/postgredeps"
+	"kantoku/impl/deps/postgres/batched"
 	redivent "kantoku/impl/platform/event/redis"
 	"kantoku/platform"
 	"kantoku/unused/backend/framework/depot"
@@ -52,9 +52,9 @@ func makePostgresClient(ctx context.Context) *pgxpool.Pool {
 	return client
 }
 
-func MakeDeps() *postgredeps.Deps {
+func MakeDeps() *batched.Deps {
 	pg := makePostgresClient(context.Background())
-	deps := postgredeps.New(
+	deps := batched.New(
 		pg,
 		redipool.New[string](makeRedisClient(), strcodec.Codec{}, "depot_groups"),
 	)


### PR DESCRIPTION
Changes Pool interface to work with transactions
Adds Instant implementation of deps, it puts resolved deps in pull, from where they can be processd immidiately.
Previous implementation is preserved and named Batched.

TODO:

- [x] implement new pool
- [x] fix incompatibility with the previous usages
- [x] run tests for both Batched and Instant deps